### PR TITLE
WDF-1113 handle expired refresh token

### DIFF
--- a/src/GrantType/GrantTypeBase.php
+++ b/src/GrantType/GrantTypeBase.php
@@ -93,6 +93,7 @@ abstract class GrantTypeBase implements GrantTypeInterface
             if ($e->getResponse()->getStatusCode() === 400)  {
                 throw new RefreshTokenExpired();
             }
+            throw $e;
         }
 
         $data = $response->json();

--- a/src/GrantType/RefreshTokenExpired.php
+++ b/src/GrantType/RefreshTokenExpired.php
@@ -1,0 +1,10 @@
+<?php
+namespace CommerceGuys\Guzzle\Oauth2\GrantType;
+
+
+use Exception;
+
+class RefreshTokenExpired extends Exception
+{
+
+}

--- a/src/GrantType/TooManyRefreshAttempts.php
+++ b/src/GrantType/TooManyRefreshAttempts.php
@@ -1,0 +1,10 @@
+<?php
+namespace CommerceGuys\Guzzle\Oauth2\GrantType;
+
+
+use Exception;
+
+class TooManyRefreshAttempts extends Exception
+{
+
+}

--- a/src/Oauth2Subscriber.php
+++ b/src/Oauth2Subscriber.php
@@ -51,7 +51,7 @@ class Oauth2Subscriber implements SubscriberInterface
     public function onError(ErrorEvent $event)
     {
         $response = $event->getResponse();
-        if ($response && 401 == $response->getStatusCode()) {
+        if ($response && (401 == $response->getStatusCode() || 400 == $response->getStatusCode())) {
             $request = $event->getRequest();
             if ($request->getConfig()->get('auth') == 'oauth2' && !$request->getConfig()->get('retried')) {
                 if ($token = $this->acquireAccessToken()) {

--- a/src/Oauth2Subscriber.php
+++ b/src/Oauth2Subscriber.php
@@ -56,7 +56,7 @@ class Oauth2Subscriber implements SubscriberInterface
     public function onError(ErrorEvent $event)
     {
         $response = $event->getResponse();
-        if ($response && (401 == $response->getStatusCode() || 400 == $response->getStatusCode())) {
+        if ($response && 401 == $response->getStatusCode()) {
             $request = $event->getRequest();
             if ($request->getConfig()->get('auth') == 'oauth2' && !$request->getConfig()->get('retried')) {
                 if ($token = $this->acquireAccessToken()) {


### PR DESCRIPTION
When requesting a new access token, if the refresh token has expired, the response will be 400 Bad Request. This change will force the client fully authenticate again which will acquire both a new access token and refresh token.